### PR TITLE
Add PSRDNoise implementations for 2D and 3D

### DIFF
--- a/addons/ShaderFunction-Extras/Noise/LicenseInfo.md
+++ b/addons/ShaderFunction-Extras/Noise/LicenseInfo.md
@@ -1,0 +1,13 @@
+# License Information
+
+## noise.gdshaderinc
+
+```md
+Copyright 2021, Stefan Gustavson and Ian MacEwan (stefan.gustavson@gmail.com, ijm567@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/addons/ShaderFunction-Extras/Noise/noise.gdshaderinc
+++ b/addons/ShaderFunction-Extras/Noise/noise.gdshaderinc
@@ -1,0 +1,123 @@
+// psrdnoise (c) Stefan Gustavson and Ian McEwan,
+// ver. 2021-12-02, published under the MIT license:
+// https://github.com/stegu/psrdnoise/
+
+vec4 __psrdnoise3_permute(vec4 i) {
+     vec4 im = mod(i, 289.0);
+     return mod(((im*34.0)+10.0)*im, 289.0);
+}
+
+float psrdnoise3_with_gradient(vec3 x, vec3 period, float alpha, out vec3 gradient)
+{
+  const mat3 M = mat3(vec3(0.0, 1.0, 1.0), vec3(1.0, 0.0, 1.0), vec3(1.0, 1.0, 0.0));
+  const mat3 Mi = mat3(vec3(-0.5, 0.5, 0.5), vec3(0.5,-0.5, 0.5), vec3(0.5, 0.5,-0.5));
+  vec3 uvw = M * x;
+  vec3 i0 = floor(uvw), f0 = fract(uvw);
+  vec3 g_ = step(f0.xyx, f0.yzz), l_ = 1.0 - g_;
+  vec3 g = vec3(l_.z, g_.xy), l = vec3(l_.xy, g_.z);
+  vec3 o1 = min( g, l ), o2 = max( g, l );
+  vec3 i1 = i0 + o1, i2 = i0 + o2, i3 = i0 + vec3(1.0);
+  vec3 v0 = Mi * i0, v1 = Mi * i1, v2 = Mi * i2, v3 = Mi * i3;
+  vec3 x0 = x - v0, x1 = x - v1, x2 = x - v2, x3 = x - v3;
+  if(any(greaterThan(period, vec3(0.0)))) {
+    vec4 vx = vec4(v0.x, v1.x, v2.x, v3.x);
+    vec4 vy = vec4(v0.y, v1.y, v2.y, v3.y);
+    vec4 vz = vec4(v0.z, v1.z, v2.z, v3.z);
+	if(period.x > 0.0) vx = mod(vx, period.x);
+	if(period.y > 0.0) vy = mod(vy, period.y);
+	if(period.z > 0.0) vz = mod(vz, period.z);
+	i0 = floor(M * vec3(vx.x, vy.x, vz.x) + 0.5);
+	i1 = floor(M * vec3(vx.y, vy.y, vz.y) + 0.5);
+	i2 = floor(M * vec3(vx.z, vy.z, vz.z) + 0.5);
+	i3 = floor(M * vec3(vx.w, vy.w, vz.w) + 0.5);
+  }
+  vec4 hash = __psrdnoise3_permute( __psrdnoise3_permute( __psrdnoise3_permute( 
+              vec4(i0.z, i1.z, i2.z, i3.z ))
+            + vec4(i0.y, i1.y, i2.y, i3.y ))
+            + vec4(i0.x, i1.x, i2.x, i3.x ));
+  vec4 theta = hash * 3.883222077;
+  vec4 sz = hash * -0.006920415 + 0.996539792;
+  vec4 psi = hash * 0.108705628;
+  vec4 Ct = cos(theta), St = sin(theta);
+  vec4 sz_prime = sqrt( 1.0 - sz*sz );
+  vec4 gx, gy, gz;
+  if(alpha != 0.0) {
+    vec4 px = Ct * sz_prime, py = St * sz_prime, pz = sz;
+    vec4 Sp = sin(psi), Cp = cos(psi), Ctp = St*Sp - Ct*Cp;
+    vec4 qx = mix( Ctp*St, Sp, sz), qy = mix(-Ctp*Ct, Cp, sz);
+    vec4 qz = -(py*Cp + px*Sp);
+    vec4 Sa = vec4(sin(alpha)), Ca = vec4(cos(alpha));
+    gx = Ca*px + Sa*qx; gy = Ca*py + Sa*qy; gz = Ca*pz + Sa*qz;
+  }
+  else {
+    gx = Ct * sz_prime; gy = St * sz_prime; gz = sz;  
+  }
+  vec3 g0 = vec3(gx.x, gy.x, gz.x), g1 = vec3(gx.y, gy.y, gz.y);
+  vec3 g2 = vec3(gx.z, gy.z, gz.z), g3 = vec3(gx.w, gy.w, gz.w);
+  vec4 w = 0.5-vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3));
+  w = max(w, 0.0); vec4 w2 = w * w, w3 = w2 * w;
+  vec4 gdotx = vec4(dot(g0,x0), dot(g1,x1), dot(g2,x2), dot(g3,x3));
+  float n = dot(w3, gdotx);
+  vec4 dw = -6.0 * w2 * gdotx;
+  vec3 dn0 = w3.x * g0 + dw.x * x0;
+  vec3 dn1 = w3.y * g1 + dw.y * x1;
+  vec3 dn2 = w3.z * g2 + dw.z * x2;
+  vec3 dn3 = w3.w * g3 + dw.w * x3;
+  gradient = 39.5 * (dn0 + dn1 + dn2 + dn3);
+  return 39.5 * n;
+}
+
+float psrdnoise3(vec3 x, vec3 period, float alpha)
+{
+	vec3 gradient;
+	return psrdnoise3_with_gradient(x, period, alpha, gradient);
+}
+
+float psrdnoise2_with_gradient(vec2 x, vec2 period, float alpha, out vec2 gradient)
+{
+  vec2 uv = vec2(x.x+x.y*0.5, x.y);
+  vec2 i0 = floor(uv), f0 = fract(uv);
+  float cmp = step(f0.y, f0.x);
+  vec2 o1 = vec2(cmp, 1.0-cmp);
+  vec2 i1 = i0 + o1, i2 = i0 + 1.0;
+  vec2 v0 = vec2(i0.x - i0.y*0.5, i0.y);
+  vec2 v1 = vec2(v0.x + o1.x - o1.y*0.5, v0.y + o1.y);
+  vec2 v2 = vec2(v0.x + 0.5, v0.y + 1.0);
+  vec2 x0 = x - v0, x1 = x - v1, x2 = x - v2;
+  vec3 iu, iv, xw, yw;
+  if(any(greaterThan(period, vec2(0.0)))) {
+    xw = vec3(v0.x, v1.x, v2.x);
+    yw = vec3(v0.y, v1.y, v2.y);
+    if(period.x > 0.0)
+    xw = mod(vec3(v0.x, v1.x, v2.x), period.x);
+    if(period.y > 0.0)
+      yw = mod(vec3(v0.y, v1.y, v2.y), period.y);
+    iu = floor(xw + 0.5*yw + 0.5); iv = floor(yw + 0.5);
+  } else {
+    iu = vec3(i0.x, i1.x, i2.x); iv = vec3(i0.y, i1.y, i2.y);
+  }
+  vec3 hash = mod(iu, 289.0);
+  hash = mod((hash*51.0 + 2.0)*hash + iv, 289.0);
+  hash = mod((hash*34.0 + 10.0)*hash, 289.0);
+  vec3 psi = hash*0.07482 + alpha;
+  vec3 gx = cos(psi); vec3 gy = sin(psi);
+  vec2 g0 = vec2(gx.x, gy.x);
+  vec2 g1 = vec2(gx.y, gy.y);
+  vec2 g2 = vec2(gx.z, gy.z);
+  vec3 w = 0.8 - vec3(dot(x0, x0), dot(x1, x1), dot(x2, x2));
+  w = max(w, 0.0); vec3 w2 = w*w; vec3 w4 = w2*w2;
+  vec3 gdotx = vec3(dot(g0, x0), dot(g1, x1), dot(g2, x2));
+  float n = dot(w4, gdotx);
+  vec3 w3 = w2*w; vec3 dw = -8.0*w3*gdotx;
+  vec2 dn0 = w4.x*g0 + dw.x*x0;
+  vec2 dn1 = w4.y*g1 + dw.y*x1;
+  vec2 dn2 = w4.z*g2 + dw.z*x2;
+  gradient = 10.9*(dn0 + dn1 + dn2);
+  return 10.9*n;
+}
+
+float psrdnoise2(vec2 x, vec2 period, float alpha)
+{
+	vec2 gradient;
+	return psrdnoise2_with_gradient(x, period, alpha, gradient);
+}


### PR DESCRIPTION
This PR adds 2D and 3D versions of the excellent [PSRDNoise algorithm](https://github.com/stegu/psrdnoise).

Notes:

- The code is an almost 1:1 copy of the original `psrdnoise2-min.glsl` and `psrdnoise3-min.glsl` files. Only the `mat3` initialization in `psrdnoise3` had to be changed to match Godot's preferred matrix instantiation signature.
- I've tested both functions and can confirm that everything is working.
- In the original files, the functions were always called `psrdnoise`. I've renamed them to `psrdnoise2` and `psrdnoise3` so both can be imported without conflict.
- ~~Both functions allow for a final `out vec2/3 gradient` parameter. This is a very useful, but purely optional feature, but the signature will always require the user to provide a variable here, even if they don't use it, which is a little bit annoying. I'm not sure if Godot's shading language allows for making parameters optional? If not, I could provide additional overloads that do away with the parameter. Please let me know what you think.~~
  - After finding out that Godot's shader language [doesn't support function overloading](https://github.com/godotengine/godot-proposals/issues/2808), I've pushed another commit that provides `psrdnoise3` and `psrdnoise3_with_gradient` (and same for `2`) functions.
- ~~Similarly, `psrdnoise3.gdshaderinc` exports a `permute` function. The potential for namespace collisions (especially if you later want to add other noise implementations) is high. How should we proceed here? We should probably rename the function to something a little less generic — anything else?~~
  - I've renamed it to `__psrdnoise3_permute`. If there is anything else we should do with it, let me know.