### PR TITLE
Download artifact file instead of repackaging the directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,9 @@ jobs:
           path: |
             ${{ github.workspace }}/addons/ShaderFunction-Extras/*
 
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.1
+      - uses: actions/download-artifact@v3
         with:
-          type: 'zip'
-          filename: '${{ github.event.repository.name }}.zip'
-          path: '${{ github.workspace }}/addons/ShaderFunction-Extras/'
+          name: ${{ github.event.repository.name }}
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Create and upload asset


### PR DESCRIPTION
Fixes the deep packaging of the addon by downloading the uploaded artifact