### PR TITLE
Added world_position_from_depth, screen_normal_world_space, rotation_matrix_by_axis, rotate_by_axis, soft_clamp, and smooth_clamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,16 @@ All these shader functions are based on publicly available shader functions (ope
   * `linear_scene_depth_*`
   * `distance_fade`
   * `proximity_fade_*`
+  * `world_position_from_depth_*`
+  * `screen_normal_world_space`
+  * `rotation_matrix_by_axis`
+  * `rotate_by_axis`
   * `random_range`
   * `remap`
   * `fresnel`
   * `fresnel_glow`
+  * `smooth_clamp`
+  * `soft_clamp`
 
   ### UV
   * `uv_panning`

--- a/addons/ShaderFunction-Extras/Utility/utility.gdshaderinc
+++ b/addons/ShaderFunction-Extras/Utility/utility.gdshaderinc
@@ -1,13 +1,21 @@
-float linear_scene_depth_vulkan(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat) {
+vec4 depth_world_pos_vulkan(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat) {
 	float log_depth = texture(depth_tex, screen_uv).x;
-	vec4 depth_world_pos = inv_proj_mat * vec4(vec3(screen_uv, log_depth) * 2.0 - 1.0, 1.0);
+	return inv_proj_mat * vec4(vec3(screen_uv, log_depth) * 2.0 - 1.0, 1.0);
+}
+
+vec4 depth_world_pos_gles(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat) {
+	float log_depth = texture(depth_tex, screen_uv).x;
+	return inv_proj_mat * vec4(screen_uv * 2.0 - 1.0, log_depth, 1.0);
+}
+
+float linear_scene_depth_vulkan(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat) {
+	vec4 depth_world_pos = depth_world_pos_vulkan(depth_tex, screen_uv, inv_proj_mat);
 	depth_world_pos.xyz /= depth_world_pos.w;
 	return -depth_world_pos.z;
 }
 
 float linear_scene_depth_gles(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat) {
-	float log_depth = texture(depth_tex, screen_uv).x;
-	vec4 depth_world_pos = inv_proj_mat * vec4(screen_uv * 2.0 - 1.0, log_depth, 1.0);
+	vec4 depth_world_pos = depth_world_pos_gles(depth_tex, screen_uv, inv_proj_mat);
 	depth_world_pos.xyz /= depth_world_pos.w;
 	return -depth_world_pos.z;
 }
@@ -17,15 +25,57 @@ float distance_fade(float min_dist, float max_dist, vec3 vertex) {
 }
 
 float proximity_fade_vulkan(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat, vec3 vertex, float fade_dist) {
-	float log_depth = texture(depth_tex, screen_uv).x;
-	vec4 depth_world_pos = inv_proj_mat * vec4(vec3(screen_uv, log_depth) * 2.0 - 1.0, 1.0);
+	vec4 depth_world_pos = depth_world_pos_vulkan(depth_tex, screen_uv, inv_proj_mat);
 	return clamp(1.0 - smoothstep(depth_world_pos.z + fade_dist, depth_world_pos.z, vertex.z), 0.0, 1.0);
 }
 
 float proximity_fade_gles(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat, vec3 vertex, float fade_dist) {
-	float log_depth = texture(depth_tex, screen_uv).x;
-	vec4 depth_world_pos = inv_proj_mat * vec4(screen_uv * 2.0 - 1.0, log_depth, 1.0);
+	vec4 depth_world_pos = depth_world_pos_gles(depth_tex, screen_uv, inv_proj_mat);
 	return clamp(1.0 - smoothstep(depth_world_pos.z + fade_dist, depth_world_pos.z, vertex.z), 0.0, 1.0);
+}
+
+vec3 world_position_from_depth_vulkan(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat, mat4 inv_view_mat) {
+	vec4 depth_world_pos = depth_world_pos_vulkan(depth_tex, screen_uv, inv_proj_mat);
+	depth_world_pos.xyz /= depth_world_pos.w;
+	return (inv_view_mat * depth_world_pos).xyz;
+}
+
+vec3 world_position_from_depth_gles(sampler2D depth_tex, vec2 screen_uv, mat4 inv_proj_mat, mat4 inv_view_mat) {
+	vec4 depth_world_pos = depth_world_pos_gles(depth_tex, screen_uv, inv_proj_mat);
+	depth_world_pos.xyz /= depth_world_pos.w;
+	return (inv_view_mat * depth_world_pos).xyz;
+}
+
+vec3 screen_normal_world_space(sampler2D normal_rough_tex, vec2 screen_uv, mat4 inv_view_mat) {
+	vec3 normals = texture(normal_rough_tex, screen_uv).xyz;
+	normals = normals * 2.0 - 1.0;
+	return mat3(inv_view_mat) * normals;
+}
+
+mat4 rotation_matrix_by_axis(float angle, vec3 axis) {
+	vec3 n_axis = normalize(axis);
+	mat3 rot_matrix = mat3(
+		vec3(
+			cos(angle) + n_axis.x * n_axis.x * (1.0 - cos(angle)),
+			n_axis.x * n_axis.y * (1.0 - cos(angle)) - n_axis.z * sin(angle),
+			n_axis.x * n_axis.z * (1.0 - cos(angle)) + n_axis.y * sin(angle)
+		),
+		vec3(
+			n_axis.y * n_axis.x * (1.0 - cos(angle)) + n_axis.z * sin(angle),
+			cos(angle) + n_axis.y * n_axis.y * (1.0 - cos(angle)),
+			n_axis.y * n_axis.z * (1.0 - cos(angle)) - n_axis.x * sin(angle)
+		),
+		vec3(
+			n_axis.z * n_axis.x * (1.0 - cos(angle)) - n_axis.y * sin(angle),
+			n_axis.z * n_axis.y * (1.0 - cos(angle)) + n_axis.x * sin(angle),
+			cos(angle) + n_axis.z * n_axis.z * (1.0 - cos(angle))
+		)
+	);
+	return mat4(rot_matrix);
+}
+
+vec3 rotate_by_axis(vec3 input, float angle, vec3 axis) {
+	return input * mat3(rotation_matrix_by_axis(angle, axis));
 }
 
 // 3D Noise with friendly permission by Inigo Quilez\n";
@@ -50,4 +100,12 @@ float fresnel(float amount, vec3 normal, vec3 view) {
 
 vec3 fresnel_glow(float amount, float intensity, vec3 color, vec3 normal, vec3 view) {
 	return pow((1.0 - dot(normalize(normal), normalize(view))), amount) * color * intensity;
+}
+
+float smooth_clamp(float value, float min, float max) {
+	return smoothstep(0.0, 1.0, (value - min) / (max - min)) * (max - min) + min;
+}
+
+float soft_clamp(float value, float min, float max) {
+	return smoothstep(0.0, 1.0, (2.0 / 3.0) * (value - min) / (max - min) + (1.0 / 6.0)) * (max - min) + min;
 }


### PR DESCRIPTION
Added to achieve parity with VisualShaders from: https://github.com/godotengine/godot/pull/72664

Also, added soft and smooth clamp, ie: https://www.shadertoy.com/view/Ws3Xzr

  ### Utility
  * `world_position_from_depth_*`
  * `screen_normal_world_space`
  * `rotation_matrix_by_axis`
  * `rotate_by_axis`
  * `smooth_clamp`
  * `soft_clamp`